### PR TITLE
Basic single pilgrim algorithm

### DIFF
--- a/bots/mainbot/pilgrim.js
+++ b/bots/mainbot/pilgrim.js
@@ -1,0 +1,152 @@
+'use strict';
+
+import {BCAbstractRobot, SPECS} from 'battlecode';
+
+const pilgrim = {};
+
+pilgrim.mission = undefined;
+pilgrim.target = undefined;
+pilgrim.home = undefined;
+
+// Find the closest Karbonite deposit to my current location
+pilgrim.findClosestKarbonite = (self) => {
+	var closestLocation = undefined;
+	var closestDistance = Infinity;
+	
+	var i, j;
+	for (i = 0; i < self.karbonite_map.length; i++) {
+		for (j = 0; j < self.karbonite_map[i].length; j++) {
+			if (self.karbonite_map[i][j]) {
+				var distance = Math.pow(self.me.x - j, 2) + Math.pow(self.me.y - i, 2);
+				if (distance < closestDistance) {
+					closestDistance = distance;
+					closestLocation = {x: j, y: i};
+				}
+			}
+		}
+	}
+
+	self.log(`Found karbonite at (${closestLocation.x}, ${closestLocation.y})`);
+	return closestLocation;
+}
+	
+// Find the closest fuel deposit to my current location
+pilgrim.findClosestFuel = (self) => {
+	var closestLocation = undefined;
+	var closestDistance = Infinity;
+	
+	var i, j;
+	for (i = 0; i < self.fuel_map.length; i++) {
+		for (j = 0; j < self.fuel_map[i].length; j++) {
+			if (self.fuel_map[i][j]) {
+				var distance = Math.pow(self.me.x - j, 2) + Math.pow(self.me.y - i, 2);
+				if (distance < closestDistance) {
+					closestDistance = distance;
+					closestLocation = {x: j, y: i};
+				}
+			}
+		}
+	}
+
+	self.log(`Found fuel at (${closestLocation.x}, ${closestLocation.y})`);
+	return closestLocation;
+}
+
+pilgrim.takeTurn = (self) => {
+	// Record home location of castle to give collected resources to
+	if (pilgrim.home === undefined) {
+		for (var robot of self.getVisibleRobots()) {
+			if (robot.unit === SPECS.CASTLE) {
+				pilgrim.home = {x: robot.x, y: robot.y};
+				self.log(`Castle at (${pilgrim.home.x}, ${pilgrim.home.y})`);
+				break;
+			}
+		}
+		if (pilgrim.home === undefined) {
+			self.log("No castle found!");
+		}
+	}
+
+	switch (pilgrim.mission) {
+		case undefined:
+			if (self.karbonite < 500) {
+				pilgrim.mission = 'karbonite'
+			} else {
+				pilgrim.mission = 'fuel'
+			}
+			pilgrim.target = undefined;
+			self.log ("Pilgrim " + self.id + " on " + pilgrim.mission + " mission")
+			break;
+		
+		case 'karbonite':
+			if (pilgrim.target === undefined) {
+				pilgrim.target = pilgrim.findClosestKarbonite(self);
+			} else if (pilgrim.target.x === self.me.x && pilgrim.target.y === self.me.y) {
+				if (self.me.karbonite < SPECS.UNITS[SPECS.PILGRIM].KARBONITE_CAPACITY) {
+					self.log(`Mining Karbonite at (${self.me.x}, ${self.me.y}) (Current: ${self.me.karbonite})`);
+					return self.mine();
+				} else {
+					self.log("Max karbonite capacity reached. Returning home.");
+					pilgrim.mission = 'return';
+					pilgrim.move(self, pilgrim.home);
+				}
+			} else {
+				self.log(`Target: (${pilgrim.target.x}, ${pilgrim.target.y})    Location: ${[self.me.x, self.me.y]}`)
+				return pilgrim.move(self, pilgrim.target);
+			}
+			break;
+
+		case 'fuel':
+			if (pilgrim.target === undefined) {
+				pilgrim.target = pilgrim.findClosestFuel(self);
+			} else if (pilgrim.target.x === self.me.x && pilgrim.target.y === self.me.y) {
+				if (self.me.fuel < SPECS.UNITS[SPECS.PILGRIM].FUEL_CAPACITY) {
+					self.log(`Mining fuel at (${self.me.x}, ${self.me.y}) (Current: ${self.me.fuel})`);
+					return self.mine();
+				} else {
+					self.log("Max fuel capacity reached. Returning home.");
+					pilgrim.mission = 'return';
+					pilgrim.move(self, pilgrim.home);
+				}
+			} else {
+				self.log(`Target: (${pilgrim.target.x}, ${pilgrim.target.y})    Location: ${[self.me.x, self.me.y]}`)
+				return pilgrim.move(self, pilgrim.target);
+			}
+			break;
+
+		case 'return':
+			if (Math.abs(self.me.x - pilgrim.home.x + self.me.y - pilgrim.home.y) < 2) {
+				pilgrim.mission = undefined;
+				self.log(`Giving ${self.me.karbonite} karbonite to castle at (${pilgrim.home.x}, ${pilgrim.home.y}), delta (${self.me.x - pilgrim.home.x}, ${self.me.y - pilgrim.home.y})`)
+				return self.give(pilgrim.home.x - self.me.x, pilgrim.home.y - self.me.y, self.me.karbonite, self.me.fuel);
+			} else {
+				return pilgrim.move(self, pilgrim.home);
+			}
+			break;
+	}
+}
+
+pilgrim.move = (self, target) => {
+	var dx = 0, dy = 0;
+	if (self.me.x < target.x) {
+		dx += 1;
+	} else if (self.me.x > target.x) {
+		dx -= 1;
+	}
+
+	if (self.me.y < target.y) {
+		dy += 1;
+	} else if (self.me.y > target.y) {
+		dy -= 1;
+	}
+
+	if (self.map[self.me.x + dx][self.me.y + dy]) {
+		self.log("Moving from (" + self.me.x + ", " + self.me.y + ") in (" + dx + ", " + dy + ") toward (" + target.x + ", " + target.y + ")");
+		return self.move(dx, dy);
+	} else {
+		self.log("Path occupied.");
+	}
+
+}
+
+export default pilgrim;

--- a/bots/mainbot/pilgrim.js
+++ b/bots/mainbot/pilgrim.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import {BCAbstractRobot, SPECS} from 'battlecode';
+import {SPECS} from 'battlecode';
 import utilities from './utilities.js'
 
 const pilgrim = {};
@@ -10,6 +10,8 @@ pilgrim.target = undefined;
 pilgrim.home = undefined;
 
 // Find the closest Karbonite deposit to my current location
+// Returns: Object with x and y properties specifying the coordinates of the
+// closest Karbonite deposit
 pilgrim.findClosestKarbonite = (self) => {
 	var closestLocation = undefined;
 	var closestDistance = Infinity;
@@ -32,6 +34,8 @@ pilgrim.findClosestKarbonite = (self) => {
 }
 	
 // Find the closest fuel deposit to my current location
+// Returns: Object with x and y properties specifying the coordinates of the
+// closest fuel deposit
 pilgrim.findClosestFuel = (self) => {
 	var closestLocation = undefined;
 	var closestDistance = Infinity;
@@ -54,17 +58,20 @@ pilgrim.findClosestFuel = (self) => {
 }
 
 pilgrim.takeTurn = (self) => {
-	// Record home location of castle to give collected resources to
+	// Record location of castle to give collected resources to
 	if (pilgrim.home === undefined) {
 		for (var robot of self.getVisibleRobots()) {
 			if (robot.unit === SPECS.CASTLE) {
 				pilgrim.home = {x: robot.x, y: robot.y};
-				utilities.log(self, `Castle at (${pilgrim.home.x}, ${pilgrim.home.y})`);
+				utilities.log(self, `Home castle at (${pilgrim.home.x}, ${pilgrim.home.y})`);
 				break;
 			}
 		}
+
+		// Unable to locate a castle within this robots visible range.
+		// Shouldn't happen under normal circumstances.
 		if (pilgrim.home === undefined) {
-			utilities.log(self, "No castle found!");
+			utilities.log(self, "ERROR! No castle found!");
 		}
 	}
 
@@ -76,21 +83,29 @@ pilgrim.takeTurn = (self) => {
 				pilgrim.mission = 'fuel'
 			}
 			pilgrim.target = undefined;
-			utilities.log(self, "Pilgrim " + self.id + " on " + pilgrim.mission + " mission")
+			utilities.log(self, `Pilgrim on ${pilgrim.mission} mission`)
 			break;
 		
 		case 'karbonite':
+			// Find the closest Karbonite deposit to mine from
 			if (pilgrim.target === undefined) {
 				pilgrim.target = pilgrim.findClosestKarbonite(self);
+
+			// On top of a karbonite deposit
 			} else if (pilgrim.target.x === self.me.x && pilgrim.target.y === self.me.y) {
+				// Mine until we're full
 				if (self.me.karbonite < SPECS.UNITS[SPECS.PILGRIM].KARBONITE_CAPACITY) {
 					utilities.log(self, `Mining Karbonite at (${self.me.x}, ${self.me.y}) (Current: ${self.me.karbonite})`);
 					return self.mine();
+
+				// Reached maximum capacity, return to home castle
 				} else {
 					utilities.log(self, "Max karbonite capacity reached. Returning home.");
 					pilgrim.mission = 'return';
 					pilgrim.move(self, pilgrim.home);
 				}
+
+			// Move toward the targeted karbonite deposit
 			} else {
 				utilities.log(self, `Target: (${pilgrim.target.x}, ${pilgrim.target.y})    Location: ${[self.me.x, self.me.y]}`)
 				return pilgrim.move(self, pilgrim.target);
@@ -98,35 +113,49 @@ pilgrim.takeTurn = (self) => {
 			break;
 
 		case 'fuel':
+			// Find the closest fuel deposit to mine from
 			if (pilgrim.target === undefined) {
 				pilgrim.target = pilgrim.findClosestFuel(self);
+
+			// On top of a fuel deposit
 			} else if (pilgrim.target.x === self.me.x && pilgrim.target.y === self.me.y) {
+				// Mine until we're full
 				if (self.me.fuel < SPECS.UNITS[SPECS.PILGRIM].FUEL_CAPACITY) {
 					utilities.log(self, `Mining fuel at (${self.me.x}, ${self.me.y}) (Current: ${self.me.fuel})`);
 					return self.mine();
+
+				// Reached maximum capacity, return to home castle
 				} else {
 					utilities.log(self, "Max fuel capacity reached. Returning home.");
 					pilgrim.mission = 'return';
 					pilgrim.move(self, pilgrim.home);
 				}
+
+			// Move toward the targeted fuel deposit
 			} else {
 				utilities.log(self, `Target: (${pilgrim.target.x}, ${pilgrim.target.y})    Location: ${[self.me.x, self.me.y]}`)
 				return pilgrim.move(self, pilgrim.target);
 			}
 			break;
 
+		// Return to home castle to deposit mined resources
 		case 'return':
+			// Adjacent to castle. Deposit resources
 			if (Math.abs(self.me.x - pilgrim.home.x) <= 1 && Math.abs(self.me.y - pilgrim.home.y) <= 1) {
 				pilgrim.mission = undefined;
 				utilities.log(self, `Giving ${self.me.karbonite} karbonite to castle at (${pilgrim.home.x}, ${pilgrim.home.y}), delta (${self.me.x - pilgrim.home.x}, ${self.me.y - pilgrim.home.y})`)
 				return self.give(pilgrim.home.x - self.me.x, pilgrim.home.y - self.me.y, self.me.karbonite, self.me.fuel);
+
+			// Move toward home castle
 			} else {
 				return pilgrim.move(self, pilgrim.home);
 			}
-			break;
 	}
 }
 
+// Move toward a target. Will only move to one of the 8 adjacent spaces around
+// the robot's current location. Will not do anything if the location the robot
+// wants to move to is impassable or occupied.
 pilgrim.move = (self, target) => {
 	var dx = 0, dy = 0;
 	if (self.me.x < target.x) {
@@ -142,7 +171,7 @@ pilgrim.move = (self, target) => {
 	}
 
 	if (utilities.isOpen(self, {x: self.me.x + dx, y: self.me.y + dy})) {
-		utilities.log(self, "Moving from (" + self.me.x + ", " + self.me.y + ") in (" + dx + ", " + dy + ") toward (" + target.x + ", " + target.y + ")");
+		utilities.log(self, "Moving from (" + self.me.x + ", " + self.me.y + ") stepping (" + dx + ", " + dy + ") toward (" + target.x + ", " + target.y + ")");
 		return self.move(dx, dy);
 	} else {
 		utilities.log(self, "Path occupied.");

--- a/bots/mainbot/pilgrim.js
+++ b/bots/mainbot/pilgrim.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import {BCAbstractRobot, SPECS} from 'battlecode';
+import utilities from './utilities.js'
 
 const pilgrim = {};
 
@@ -26,7 +27,7 @@ pilgrim.findClosestKarbonite = (self) => {
 		}
 	}
 
-	self.log(`Found karbonite at (${closestLocation.x}, ${closestLocation.y})`);
+	utilities.log(self, `Found karbonite at (${closestLocation.x}, ${closestLocation.y})`);
 	return closestLocation;
 }
 	
@@ -48,7 +49,7 @@ pilgrim.findClosestFuel = (self) => {
 		}
 	}
 
-	self.log(`Found fuel at (${closestLocation.x}, ${closestLocation.y})`);
+	utilities.log(self, `Found fuel at (${closestLocation.x}, ${closestLocation.y})`);
 	return closestLocation;
 }
 
@@ -58,12 +59,12 @@ pilgrim.takeTurn = (self) => {
 		for (var robot of self.getVisibleRobots()) {
 			if (robot.unit === SPECS.CASTLE) {
 				pilgrim.home = {x: robot.x, y: robot.y};
-				self.log(`Castle at (${pilgrim.home.x}, ${pilgrim.home.y})`);
+				utilities.log(self, `Castle at (${pilgrim.home.x}, ${pilgrim.home.y})`);
 				break;
 			}
 		}
 		if (pilgrim.home === undefined) {
-			self.log("No castle found!");
+			utilities.log(self, "No castle found!");
 		}
 	}
 
@@ -75,7 +76,7 @@ pilgrim.takeTurn = (self) => {
 				pilgrim.mission = 'fuel'
 			}
 			pilgrim.target = undefined;
-			self.log ("Pilgrim " + self.id + " on " + pilgrim.mission + " mission")
+			utilities.log(self, "Pilgrim " + self.id + " on " + pilgrim.mission + " mission")
 			break;
 		
 		case 'karbonite':
@@ -83,15 +84,15 @@ pilgrim.takeTurn = (self) => {
 				pilgrim.target = pilgrim.findClosestKarbonite(self);
 			} else if (pilgrim.target.x === self.me.x && pilgrim.target.y === self.me.y) {
 				if (self.me.karbonite < SPECS.UNITS[SPECS.PILGRIM].KARBONITE_CAPACITY) {
-					self.log(`Mining Karbonite at (${self.me.x}, ${self.me.y}) (Current: ${self.me.karbonite})`);
+					utilities.log(self, `Mining Karbonite at (${self.me.x}, ${self.me.y}) (Current: ${self.me.karbonite})`);
 					return self.mine();
 				} else {
-					self.log("Max karbonite capacity reached. Returning home.");
+					utilities.log(self, "Max karbonite capacity reached. Returning home.");
 					pilgrim.mission = 'return';
 					pilgrim.move(self, pilgrim.home);
 				}
 			} else {
-				self.log(`Target: (${pilgrim.target.x}, ${pilgrim.target.y})    Location: ${[self.me.x, self.me.y]}`)
+				utilities.log(self, `Target: (${pilgrim.target.x}, ${pilgrim.target.y})    Location: ${[self.me.x, self.me.y]}`)
 				return pilgrim.move(self, pilgrim.target);
 			}
 			break;
@@ -101,23 +102,23 @@ pilgrim.takeTurn = (self) => {
 				pilgrim.target = pilgrim.findClosestFuel(self);
 			} else if (pilgrim.target.x === self.me.x && pilgrim.target.y === self.me.y) {
 				if (self.me.fuel < SPECS.UNITS[SPECS.PILGRIM].FUEL_CAPACITY) {
-					self.log(`Mining fuel at (${self.me.x}, ${self.me.y}) (Current: ${self.me.fuel})`);
+					utilities.log(self, `Mining fuel at (${self.me.x}, ${self.me.y}) (Current: ${self.me.fuel})`);
 					return self.mine();
 				} else {
-					self.log("Max fuel capacity reached. Returning home.");
+					utilities.log(self, "Max fuel capacity reached. Returning home.");
 					pilgrim.mission = 'return';
 					pilgrim.move(self, pilgrim.home);
 				}
 			} else {
-				self.log(`Target: (${pilgrim.target.x}, ${pilgrim.target.y})    Location: ${[self.me.x, self.me.y]}`)
+				utilities.log(self, `Target: (${pilgrim.target.x}, ${pilgrim.target.y})    Location: ${[self.me.x, self.me.y]}`)
 				return pilgrim.move(self, pilgrim.target);
 			}
 			break;
 
 		case 'return':
-			if (Math.abs(self.me.x - pilgrim.home.x + self.me.y - pilgrim.home.y) < 2) {
+			if (Math.abs(self.me.x - pilgrim.home.x) <= 1 && Math.abs(self.me.y - pilgrim.home.y) <= 1) {
 				pilgrim.mission = undefined;
-				self.log(`Giving ${self.me.karbonite} karbonite to castle at (${pilgrim.home.x}, ${pilgrim.home.y}), delta (${self.me.x - pilgrim.home.x}, ${self.me.y - pilgrim.home.y})`)
+				utilities.log(self, `Giving ${self.me.karbonite} karbonite to castle at (${pilgrim.home.x}, ${pilgrim.home.y}), delta (${self.me.x - pilgrim.home.x}, ${self.me.y - pilgrim.home.y})`)
 				return self.give(pilgrim.home.x - self.me.x, pilgrim.home.y - self.me.y, self.me.karbonite, self.me.fuel);
 			} else {
 				return pilgrim.move(self, pilgrim.home);
@@ -140,11 +141,11 @@ pilgrim.move = (self, target) => {
 		dy -= 1;
 	}
 
-	if (self.map[self.me.x + dx][self.me.y + dy]) {
-		self.log("Moving from (" + self.me.x + ", " + self.me.y + ") in (" + dx + ", " + dy + ") toward (" + target.x + ", " + target.y + ")");
+	if (utilities.isOpen(self, {x: self.me.x + dx, y: self.me.y + dy})) {
+		utilities.log(self, "Moving from (" + self.me.x + ", " + self.me.y + ") in (" + dx + ", " + dy + ") toward (" + target.x + ", " + target.y + ")");
 		return self.move(dx, dy);
 	} else {
-		self.log("Path occupied.");
+		utilities.log(self, "Path occupied.");
 	}
 
 }

--- a/bots/mainbot/robot.js
+++ b/bots/mainbot/robot.js
@@ -1,6 +1,7 @@
 import {BCAbstractRobot, SPECS} from 'battlecode';
 import castle from './castle.js'
 import crusader from './crusader.js'
+import pilgrim from './pilgrim.js'
 
 class MyRobot extends BCAbstractRobot {
 	constructor() {
@@ -18,6 +19,9 @@ class MyRobot extends BCAbstractRobot {
         		break;
 			case SPECS.CRUSADER:
 				this.myType = crusader;
+				break;
+			case SPECS.PILGRIM:
+				this.myType = pilgrim;
 				break;
         	default:
 				break;

--- a/bots/mainbot/utilities.js
+++ b/bots/mainbot/utilities.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const utilities = {}
+
+// Returns true if the location is a) passable and b) the current robot can not
+// see any robot in that location.
+// NOTE: If the location is outside of the current robot's vision range and a
+// robot occupies that location, this function will still return true.
+utilities.isOpen = (self, location) => {
+	if (location.x < 0 || location.y < 0) {
+		return false;
+	}
+	// utilities.log(self, `isOpen(${location.x}, ${location.y}) = ${self.map[location.y][location.x] && (self.getVisibleRobotMap()[location.y][location.x] <= 0)}`);
+	return self.map[location.y][location.x] && (self.getVisibleRobotMap()[location.y][location.x] <= 0);
+}
+
+utilities.log = (self, message) => {
+	self.log(`Round ${self.me.turn} - ${message}`);
+}
+
+export default utilities;

--- a/bots/mainbot/utilities.js
+++ b/bots/mainbot/utilities.js
@@ -14,6 +14,7 @@ utilities.isOpen = (self, location) => {
 	return self.map[location.y][location.x] && (self.getVisibleRobotMap()[location.y][location.x] <= 0);
 }
 
+// Prepend the round number before logging. May extend to log more information
 utilities.log = (self, message) => {
 	self.log(`Round ${self.me.turn} - ${message}`);
 }


### PR DESCRIPTION
Allows a single pilgrim to decide whether to mine karbonite or fuel, make a beeline for the nearest resource of that type, mine until it cannot carry any more of that resource, make a beeline for the castle that built it, drop off its collected resources, and repeat.
Current algorithm won't extend to multiple pilgrims; they will fight over the closest resource.
Current navigation algorithm will give up if it encounters an obstacle, such as a wall or another robot.