### PR TITLE
Add movement algo and send crusaders to rush enemy castles

### DIFF
--- a/bots/mainbot/combat.js
+++ b/bots/mainbot/combat.js
@@ -1,0 +1,14 @@
+'use strict';
+import {SPECS} from 'battlecode';
+import utilities from "./utilities.js";
+
+const combat = {};
+
+combat.attackBot = (self, target) => {
+    let dx = target.x - self.me.x;
+    let dy = target.y - self.me.y;
+
+    return self.attack(dx, dy);
+};
+
+export default combat;

--- a/bots/mainbot/crusader.js
+++ b/bots/mainbot/crusader.js
@@ -1,13 +1,38 @@
 import {BCAbstractRobot, SPECS} from 'battlecode';
+import movement from './movement.js'
+import utilities from './utilities.js'
+import combat from './combat.js'
 
 const crusader = {};
 
 crusader.takeTurn = (self) => {
-	self.log("Crusader health: " + self.me.health);
-	const choices = [[0,-1], [1, -1], [1, 0], [1, 1], [0, 1], [-1, 1], [-1, 0], [-1, -1]];
-	const choice = choices[Math.floor(Math.random()*choices.length)]
-	return self.move(...choice);
+	let enemies = utilities.enemiesInRange(self);
+	if (self.moveQueue === undefined) {
+		self.moveQueue = [];
+	}
+    if(enemies.length > 0){
+        for(let i = 0; i < enemies.length; ++i){
+        	if(enemies[i].unit === SPECS.CASTLE){
+        		self.log("Attacking Castle");
+        		return combat.attackBot(self, enemies[i]);
+			}
+		}
+    }
+    if (self.step === 0 ){
+    	self.log("Searching for castle on horizontal symmetric map");
+        self.moveQueue = movement.moveTo(self, (self.map[0].length - self.me.x), (self.me.y))
+    }
+	if (self.moveQueue.length !== 0) {
+		let move = self.moveQueue.shift();
+		self.log("moving to " + (move.x) + ', ' + (move.y));
+		return self.move((move.x - self.me.x), (move.y - self.me.y));
+	}
+    else if(self.step !== 0 && enemies.length < 1){
+    	self.log("Searching for castle on vertically symmetric map");
+        self.moveQueue = movement.moveTo(self, (self.map[0].length - self.me.x), (self.map.length - self.me.y))
+    }
 
-}
+
+};
 
 export default crusader;

--- a/bots/mainbot/movement.js
+++ b/bots/mainbot/movement.js
@@ -1,0 +1,162 @@
+'use strict';
+
+import {SPECS} from 'battlecode';
+import utilities from "./utilities.js";
+const movement = {};
+
+movement.moveTo = (self, x, y) => {
+    if(!self.map[x] || !self.map[0][y]){
+        return [];
+    }
+    let path = movement.aStar(self, [self.me.y, self.me.x], [y, x], self.map);
+    return path
+};
+
+
+movement.aStar = (self, start, dest, theMap) => {
+    // List of available discovered nodes
+    let openList = [];
+    // The map
+    let map = [];
+
+    // Used to hold nodes adjacent to curr
+    let adjacent = [];
+
+    // Used to track the current square
+    let curr = null;
+    // Use to get the index of the selected node, this way we can remove it from the openList
+    let currIndex = 0;
+    let neighbor = null;
+    let gScore = 0;
+
+    // Set up the map. If map[x][y] is false then it is impassable
+    for (let y = 0; y < theMap.length; ++y) {
+        map[y] = [];
+        for (let x = 0; x < theMap[y].length; ++x) {
+            map[y][x] =
+                { g:0,
+                  h:0,
+                  f:0,
+                  x:x,
+                  y:y,
+                  parent:null,
+                  seen:false };
+            if(theMap[y][x]) {
+                map[y][x].closed = false;
+            }
+            else{
+                map[y][x].closed = true;
+            }
+        }
+    }
+
+    let goal = map[dest[0]][dest[1]];
+
+    // If the target dest is impassable
+    if (!goal){
+        return false;
+    }
+
+    // Start at the bot's current position
+    openList.push(map[start[0]][start[1]]);
+
+    while (openList.length > 0) {
+        currIndex = movement.selectNext(openList);
+        curr = openList[currIndex];
+
+        if(curr === goal) {
+            return movement.retracePath(self, start, goal)
+        }
+        // Take the current node off of the openList and set it to closed
+        openList.splice(currIndex, 1);
+        curr.closed = true;
+
+        adjacent = movement.getOpenAdj(map, curr);
+
+        for(let i = 0; i < adjacent.length; ++i){
+            neighbor = adjacent[i];
+            gScore = curr.g + utilities.getDistance(curr, neighbor);
+
+            if(!neighbor.seen){
+                neighbor.seen = true;
+                openList.push(neighbor);
+                neighbor.parent = curr;
+                neighbor.g = gScore;
+                neighbor.h = utilities.getDistance(curr, goal);
+                neighbor.f = neighbor.g + neighbor.h
+            }
+            else if(gScore < neighbor.g){
+                neighbor.parent = curr;
+                neighbor.g = gScore;
+                neighbor.h = utilities.getDistance(curr, goal);
+                neighbor.f = neighbor.g + neighbor.h
+            }
+
+        }
+
+    }
+
+};
+
+movement.retracePath = (self, start, goal) => {
+    // Start at the end of the path and work back to the start
+    let parent = goal.parent;
+    let path = [];
+
+    path.push(goal);
+    while(parent !== null && parent !== start){
+        path.push(parent);
+        parent = parent.parent
+    }
+    return path.reverse();
+};
+
+movement.selectNext = (openList) => {
+    let min = openList[0].f;
+    let minInd = 0;
+
+    for (let i=1; i < openList.length; ++i){
+        if (openList[i].f < min){
+            minInd = i
+        }
+    }
+    return minInd
+};
+
+movement.getOpenAdj = (map, curr) => {
+
+    // All adjacent nodes
+    let adj;
+    if(!map[0][curr.x+1]){
+        adj = [map[curr.y][curr.x - 1], map[curr.y + 1][curr.x], map[curr.y - 1][curr.x],
+               map[curr.y - 1][curr.x - 1], map[curr.y + 1][curr.x -1]];
+    }
+    else if(!map[0][curr.x-1]){
+        adj = [map[curr.y][curr.x + 1], map[curr.y + 1][curr.x], map[curr.y - 1][curr.x],
+               map[curr.y + 1][curr.x + 1], map[curr.y - 1][curr.x + 1]];
+    }
+    else if(!map[curr.y+1]){
+        adj = [map[curr.y][curr.x + 1], map[curr.y][curr.x - 1], map[curr.y - 1][curr.x],
+               map[curr.y - 1][curr.x - 1], map[curr.y - 1][curr.x + 1]];
+    }
+    else if(!map[curr.y-1]){
+        adj = [map[curr.y][curr.x + 1], map[curr.y][curr.x - 1], map[curr.y + 1][curr.x],
+               map[curr.y + 1][curr.x + 1], map[curr.y + 1][curr.x -1]];
+    }
+    else{
+        adj = [map[curr.y][curr.x + 1], map[curr.y][curr.x - 1], map[curr.y + 1][curr.x], map[curr.y - 1][curr.x],
+               map[curr.y + 1][curr.x + 1], map[curr.y - 1][curr.x - 1], map[curr.y - 1][curr.x + 1], map[curr.y + 1][curr.x -1]];
+    }
+    // All adjacent nodes that are open
+    let openAdj = [];
+
+    for(let i = 0; i < adj.length; ++i){
+        if(adj[i] && !adj[i].closed){
+            openAdj.push(adj[i])
+        }
+    }
+    return openAdj
+};
+
+
+export default movement;

--- a/bots/mainbot/robot.js
+++ b/bots/mainbot/robot.js
@@ -8,6 +8,7 @@ class MyRobot extends BCAbstractRobot {
         super();
         this.myType = undefined;
         this.step = -1;
+        this.moveQueue = [];
     }
 	
 	turn() {

--- a/bots/mainbot/utilities.js
+++ b/bots/mainbot/utilities.js
@@ -1,6 +1,7 @@
 'use strict';
+import {SPECS} from 'battlecode';
 
-const utilities = {}
+const utilities = {};
 
 // Returns true if the location is a) passable and b) the current robot can not
 // see any robot in that location.
@@ -12,11 +13,31 @@ utilities.isOpen = (self, location) => {
 	}
 	// utilities.log(self, `isOpen(${location.x}, ${location.y}) = ${self.map[location.y][location.x] && (self.getVisibleRobotMap()[location.y][location.x] <= 0)}`);
 	return self.map[location.y][location.x] && (self.getVisibleRobotMap()[location.y][location.x] <= 0);
-}
+};
 
 // Prepend the round number before logging. May extend to log more information
 utilities.log = (self, message) => {
 	self.log(`Round ${self.me.turn} - ${message}`);
-}
+};
+
+utilities.enemiesInRange = (self) => {
+	let enemies = [];
+	let botSpec = SPECS['UNITS'][self.me.unit];
+	let minRange = botSpec['ATTACK_RADIUS'][0];
+	let maxRange = botSpec['ATTACK_RADIUS'][1];
+	let myTeam = self.me.team;
+	let robotsInVision = self.getVisibleRobots();
+	for(let i = 0; i < robotsInVision.length; ++i){
+		if(robotsInVision[i].team !== myTeam && Math.pow(utilities.getDistance(self.me, robotsInVision[i]), 2) < maxRange){
+			enemies.push(robotsInVision[i])
+		}
+	}
+	return enemies;
+};
+
+utilities.getDistance = (start, end) => {
+    //get the manhattan distance
+    return (Math.abs(start.x - end.x) + Math.abs(start.y - end.y))
+};
 
 export default utilities;


### PR DESCRIPTION
The movement algorithm is an A* algorithm that should avoid any walls. I can still clean it up to make bots move faster. For now each step is only 1 block away. The algorithm returns the path to the destination which you should pop the next step off the array and move there each turn until you reach the end. Crusader.js has an example of how to use the new function. Keep in the mind the algorithm does not take into account any bots, so if a bot occupies the square you try to move to, it may be occupied. 

I added logic to the crusader.js file to search for the enemy castle based on symmetry. If they can't find castles at the horizontal symmetry location they will double back to the vertical symmetric location. 