### PR TITLE
Add phases

### DIFF
--- a/bots/mainbot/castle.js
+++ b/bots/mainbot/castle.js
@@ -7,16 +7,29 @@ import combat from './combat.js'
 
 const castle = {};
 const pilgrims ={};
+
+
 pilgrims.number = 0;
 var castle_ids = [];
 var builds = 0;
 var buildunitflag =0 ;
 castle.takeTurn = (self) => {
-	
-	self.log('castle taking turn')
+
+    self.log('castle taking turn')
+	const visible = self.getVisibleRobots();
+	//self.log('the visbile robots are:' + visible) ;
+    castle.countUnits(self, visible);
+
+    utilities.log(self, `Current unit counts: Castles: ${self.castle_count}, Crusaders: ${self.crusader_count}, Prophets: ${self.prophet_count}, Pilgrims: ${self.pilgrim_count}`)
+
+	if(self.prophet_count >= 5){
+        self.signal(0x01, 5);
+        utilities.log(self, "Castle setting attack phase")
+	}
+
 	var robotsnearme = self.getVisibleRobots();
 
-			
+
 	var attackable = robotsnearme.filter((r) => {
 		if (! self.isVisible(r)){
 			return false;
@@ -30,20 +43,20 @@ castle.takeTurn = (self) => {
 		return false;
 	});
 
-	if (attackable.length>0 && self.me.health > 50 ){
+	if (attackable.length>0){
         // attack first robot
         var r = attackable[0];
         self.log('' +r);
         self.log('attacking! ' + r + ' at loc ' + (r.x - self.me.x, r.y - self.me.y));
         return self.attack(r.x - self.me.x, r.y - self.me.y);
-	} 
+	}
 
 	var getBuildDir = function(buildunit) {
 		var options = nav.rotate_arr.filter((d) => {
 			return nav.isPassable(nav.applyDir(self.me, d), self.getPassableMap(), self.getVisibleRobotMap())
 		})
 		return options[0];
-	} 
+	}
 
 	if(self.me['turn'] == '1')
 	{
@@ -54,22 +67,22 @@ castle.takeTurn = (self) => {
 		castle_ids.sort();
 		self.log("castle_ids: " + castle_ids)
 		// self.castleTalk(1)
-	
+
 
 	}
-	
+
 	if(self.me['turn'] > 1  && pilgrims.number < 4 &&
 		self.fuel > SPECS['UNITS'][SPECS['PILGRIM']]['CONSTRUCTION_FUEL'] + 10
 			&& self.karbonite >= SPECS['UNITS'][SPECS['PILGRIM']]['CONSTRUCTION_KARBONITE'])
-	{	   
+	{
 		  var d = getBuildDir(self.me);
 		  if (!(d === undefined)){
 			  self.log('Building a pilgrim at ' + (self.me.x+1) + ',' + (self.me.y+1));
 			  pilgrims.number++;
 			  return self.buildUnit(SPECS.PILGRIM, d.x, d.y);
 			  }
-	} 
-	
+	}
+
 	if(self.me['turn'] > 1 && castle_ids.length == 1)
 	{
 		self.log("Im the only castle let me keep building")
@@ -81,7 +94,7 @@ castle.takeTurn = (self) => {
 			   buildunitflag = (buildunitflag + 1) % 2
 			    return self.buildUnit(SPECS.CRUSADER, d.x, d.y);
 			   }
-				
+
 	   	}
 		if (buildunitflag === 1 && self.karbonite > 30 && self.fuel > 100)
 		{
@@ -90,13 +103,13 @@ castle.takeTurn = (self) => {
 				self.log('Building a prophet at' + (self.me.x+1) + ',' + (self.me.y+1));
 				buildunitflag = (buildunitflag + 1) % 2
 				return self.buildUnit(SPECS.PROPHET, d.x, d.y);
-				}	
-			
-		}			
+				}
+
+		}
 	}
 
 	else if(self.me['turn'] > 1 && castle_ids.length > 1)
-	{	
+	{
 		self.log('More than 1 castle')
 
 		// Check if anybody built something
@@ -136,14 +149,14 @@ castle.takeTurn = (self) => {
 					buildunitflag = (buildunitflag + 1) % 2
 					return self.buildUnit(SPECS.PROPHET, d.x, d.y);
 					}
-				
-			}			
+
+			}
 		}
 
 		// If it's our turn, try building something.
 		if (castle_ids[builds%castle_ids.length] === self.me.id) {
 			// Build something
-						
+
 			if ( buildunitflag === 0 && self.karbonite > 30 && self.fuel > 100)
 			{
 				var d = getBuildDir(self.me);
@@ -151,8 +164,8 @@ castle.takeTurn = (self) => {
 					self.log('Building a crusader at' + (self.me.x+1) + ',' + (self.me.y+1));
 					buildunitflag = (buildunitflag + 1) % 2
 					return self.buildUnit(SPECS.CRUSADER, d.x, d.y);
-					}	
-					
+					}
+
 			}
 			if ( buildunitflag === 1 && self.karbonite > 30 && self.fuel > 100 )
 			{
@@ -161,10 +174,10 @@ castle.takeTurn = (self) => {
 					self.log('Building a prophet at' + (self.me.x+1) + ',' + (self.me.y+1));
 					buildunitflag = (buildunitflag + 1) % 2
 					return self.buildUnit(SPECS.PROPHET, d.x, d.y);
-				}	
-				
+				}
+
 			}
-		
+
 			self.log("I built something");
 			self.castleTalk(0x01);
 		}
@@ -183,20 +196,20 @@ castle.takeTurn = (self) => {
 	if(self.me['turn'] > 1 &&  pilgrims.signal < 4 &&
 		self.fuel > SPECS['UNITS'][SPECS['PILGRIM']]['CONSTRUCTION_FUEL'] + 10
 			&& self.karbonite >= SPECS['UNITS'][SPECS['PILGRIM']]['CONSTRUCTION_KARBONITE'])
-	{	   
+	{
 		  var d = getBuildDir(self.me);
 		  if (!(d === undefined)){
 			  self.log('Building a pilgrim at ' + (self.me.x+1) + ',' + (self.me.y+1));
 			  pilgrims.number++;
 			  return self.buildUnit(SPECS.PILGRIM, d.x, d.y);
 			  }
-	} 
+	}
 
 /*
 			for(var i = 0 ; i < castle_ids.length ;i++ )
 		{
 			if(castle_ids[i] % 3 == 0 && robotsnearme[i].castle_talk == 1 )
-			{ 
+			{
 				self.log('Inside mod value == 0')
 				if ( self.karbonite > 30 && self.fuel > 150)
 	   			{
@@ -204,8 +217,8 @@ castle.takeTurn = (self) => {
 		   			if (!(d === undefined)){
 					   self.log('Building a crusader at' + (self.me.x+1) + ',' + (self.me.y+1));
 					 return self.buildUnit(SPECS.CRUSADER, d.x, d.y);
-			  		 }	
-					crusadernum++	
+			  		 }
+					crusadernum++
 	   			}
 				if ( self.karbonite > 30 && self.fuel > 150 )
 				{
@@ -213,9 +226,9 @@ castle.takeTurn = (self) => {
 					if (!(d === undefined)){
 						self.log('Building a prophet at' + (self.me.x+1) + ',' + (self.me.y+1));
 						return self.buildUnit(SPECS.PROPHET, d.x, d.y);
-					}	
+					}
 					prophetnum++
-				}			
+				}
 				self.log('Crusaders built are mod ==0 :' + crusadernum)
 				self.log('prophets built are :' + prophetnum)
 
@@ -224,10 +237,10 @@ castle.takeTurn = (self) => {
 					buildflag = 1
 					self.castleTalk(1)
 				}
-				
-			}	
+
+			}
 		else if (castle_ids[i] % 3 == 1 && robotsnearme[i].castle_talk == 1)
-		{ 
+		{
 			self.log('Inside mod value == 1')
 			if ( self.karbonite > 30 && self.fuel > 150 )
 			   {
@@ -235,8 +248,8 @@ castle.takeTurn = (self) => {
 				   if (!(d === undefined)){
 				   self.log('Building a crusader at' + (self.me.x+1) + ',' + (self.me.y+1));
 				 return self.buildUnit(SPECS.CRUSADER, d.x, d.y);
-				   }	
-				crusadernum++	
+				   }
+				crusadernum++
 			   }
 			if ( self.karbonite > 30 && self.fuel > 150 )
 			{
@@ -244,9 +257,9 @@ castle.takeTurn = (self) => {
 				if (!(d === undefined)){
 					self.log('Building a prophet at' + (self.me.x+1) + ',' + (self.me.y+1));
 					return self.buildUnit(SPECS.PROPHET, d.x, d.y);
-				}	
+				}
 				prophetnum++
-			}			
+			}
 			self.log('Crusaders built are mod == 1 :' + crusadernum)
             self.log('prophets built are :' + prophetnum)
 			if(crusadernum == 5 && prophetnum == 5)
@@ -264,8 +277,8 @@ castle.takeTurn = (self) => {
 				   if (!(d === undefined)){
 				   self.log('Building a crusader at' + (self.me.x+1) + ',' + (self.me.y+1));
 				 return self.buildUnit(SPECS.CRUSADER, d.x, d.y);
-				   }	
-				crusadernum++	
+				   }
+				crusadernum++
 			   }
 			if ( self.karbonite > 30 && self.fuel > 150 )
 			{
@@ -273,9 +286,9 @@ castle.takeTurn = (self) => {
 				if (!(d === undefined)){
 					self.log('Building a prophet at' + (self.me.x+1) + ',' + (self.me.y+1));
 					return self.buildUnit(SPECS.PROPHET, d.x, d.y);
-				}	
+				}
 				prophetnum++
-			}			
+			}
 			self.log('Crusaders built are mod ==2 :' + crusadernum)
 			self.log('prophets built are :' + prophetnum)
 			if(crusadernum == 5 && prophetnum == 5)
@@ -283,11 +296,11 @@ castle.takeTurn = (self) => {
 				buildflag = 0
 				self.castleTalk(1)
 			}
-	
-		}	
-	
+
+		}
+
 	}
-	
+
 /*	if(self.me['turn'] == 2 )
 	{
 			var d = getBuildDir(self.me);
@@ -295,10 +308,10 @@ castle.takeTurn = (self) => {
 			self.log('Building a pilgrim at ' + (self.me.x+1) + ',' + (self.me.y+1));
 			pilgrims.number++;
 			return self.buildUnit(SPECS.PILGRIM, d.x, d.y);
-		} 	
-			
+		}
+
 	}
-		
+
 	if(self.me['turn'] == 3)
 	{
 		self.log('Turn 2 for blue team')
@@ -306,17 +319,17 @@ castle.takeTurn = (self) => {
 				if (!(d === undefined)){
 					self.log('Building a prophet at ' + (self.me.x+1) + ',' + (self.me.y+1));
 					 return self.buildUnit(SPECS.PROPHET, d.x, d.y);
-				}	
-				
+				}
+
 			var d = getBuildDir(self.me);
 			if (!(d === undefined)){
 			self.log('Building a pilgrim at ' + (self.me.x+1) + ',' + (self.me.y+1));
 			pilgrims.number++;
 			return self.buildUnit(SPECS.PILGRIM, d.x, d.y);
-		} 
-} */ 
-	 
-   
+		}
+} */
+
+
 
 /*	if (self.me.turn > 5 && self.me.turn % 2 == 0 && self.karbonite > 30 && self.fuel > 150 && Math.random() < .3333)
 	   {
@@ -327,7 +340,7 @@ castle.takeTurn = (self) => {
 		   return self.buildUnit(SPECS.PROPHET, d.x, d.y);
 		   }
 	   }
-	   
+
 	   if ( self.me.turn >5 && self.me.turn % 2 != 0 && self.karbonite > 30 && self.fuel > 150 && Math.random() < .3333)
 	   {
 		   var d = getBuildDir(self.me);
@@ -335,9 +348,9 @@ castle.takeTurn = (self) => {
 			   self.log('Building a crusader at(blue team)  mod 10 ' + (self.me.x+1) + ',' + (self.me.y+1));
 			   pilgrims.number++;
 			   return self.buildUnit(SPECS.CRUSADER, d.x, d.y);
-			   }	
+			   }
 	   }   */
-	   
+
 	 /*  var enemies = utilities.enemiesInRange(self);
 	   if(enemies.length > 0){
 		   for(let i = 0; i < enemies.length; ++i){
@@ -346,8 +359,38 @@ castle.takeTurn = (self) => {
 				   return combat.attackBot(self, enemies[i]);
 			   }
 		   } */
-	   
 
+
+};
+
+// Counts bots castle can see.
+castle.countUnits = (self, visibleBots) => {
+    let bot = undefined;
+    // Zero the counts
+    self.castle_count = 0;
+    self.crusader_count = 0;
+    self.pilgrim_count = 0;
+    self.prophet_count = 0;
+    for (let i = 0; i < visibleBots.length; ++i){
+        bot = visibleBots[i];
+        // utilities.log(self, `Bot at ${i} has unit ${bot.unit} and castleTalk ${bot.castleTalk}`);
+        switch (bot.unit) {
+        	case SPECS.CASTLE:
+				self.castle_count +=1;
+        		break;
+			case SPECS.CRUSADER:
+				self.crusader_count +=1;
+				break;
+			case SPECS.PILGRIM:
+				self.pilgrim_count +=1;
+				break;
+			case SPECS.PROPHET:
+				self.prophet_count +=1;
+				break;
+			default:
+				break;
+		}
+    }
 };
 
 export default castle;

--- a/bots/mainbot/castle.js
+++ b/bots/mainbot/castle.js
@@ -58,9 +58,12 @@ castle.takeTurn = (self) => {
 		return options[0];
 	}
 
-	if(self.me['turn'] == '1')
-	{
-		for(var i=0 ;i< robotsnearme.length; i++)
+		if(self.me['turn'] == '1')
+		{
+			utilities.log(self, `Castle Location: ${[self.me.x, self.me.y]}`)
+			self.castle_count = visible.length;
+			utilities.log(self, `Found ${self.castle_count} castles`);
+			for(var i=0 ;i< robotsnearme.length; i++)
 			{
 				castle_ids.push((robotsnearme[i].id))
 			}

--- a/bots/mainbot/combat.js
+++ b/bots/mainbot/combat.js
@@ -8,6 +8,8 @@ combat.attackBot = (self, target) => {
     let dx = target.x - self.me.x;
     let dy = target.y - self.me.y;
 
+    utilities.log(self, `Attempting to attack with a dx of ${dx} and dy of ${dy}`)
+
     return self.attack(dx, dy);
 };
 

--- a/bots/mainbot/crusader.js
+++ b/bots/mainbot/crusader.js
@@ -7,30 +7,31 @@ const crusader = {};
 
 crusader.takeTurn = (self) => {
 	let enemies = utilities.enemiesInRange(self);
-	if (self.moveQueue === undefined) {
-		self.moveQueue = [];
-	}
-    if(enemies.length > 0){
-        for(let i = 0; i < enemies.length; ++i){
-        	if(enemies[i].unit === SPECS.CASTLE){
-        		self.log("Attacking Castle");
-        		return combat.attackBot(self, enemies[i]);
-			}
-		}
-    }
-    if (self.step === 0 ){
-    	self.log("Searching for castle on horizontal symmetric map");
-        self.moveQueue = movement.moveTo(self, (self.map[0].length - self.me.x), (self.me.y))
-    }
-	if (self.moveQueue.length !== 0) {
-		let move = self.moveQueue.shift();
-		self.log("moving to " + (move.x) + ', ' + (move.y));
-		return self.move((move.x - self.me.x), (move.y - self.me.y));
-	}
-    else if(self.step !== 0 && enemies.length < 1){
-    	self.log("Searching for castle on vertically symmetric map");
-        self.moveQueue = movement.moveTo(self, (self.map[0].length - self.me.x), (self.map.length - self.me.y))
-    }
+	self.castleTalk(SPECS.CRUSADER)
+	// if (self.moveQueue === undefined) {
+	// 	self.moveQueue = [];
+	// }
+    // if(enemies.length > 0){
+    //     for(let i = 0; i < enemies.length; ++i){
+    //     	if(enemies[i].unit === SPECS.CASTLE){
+    //     		self.log("Attacking Castle");
+    //     		return combat.attackBot(self, enemies[i]);
+	// 		}
+	// 	}
+    // }
+    // if (self.step === 0 ){
+    // 	self.log("Searching for castle on horizontal symmetric map");
+    //     self.moveQueue = movement.moveTo(self, (self.map[0].length - self.me.x), (self.me.y))
+    // }
+	// if (self.moveQueue.length !== 0) {
+	// 	let move = self.moveQueue.shift();
+	// 	self.log("moving to " + (move.x) + ', ' + (move.y));
+	// 	return self.move((move.x - self.me.x), (move.y - self.me.y));
+	// }
+    // else if(self.step !== 0 && enemies.length < 1){
+    // 	self.log("Searching for castle on vertically symmetric map");
+    //     self.moveQueue = movement.moveTo(self, (self.map[0].length - self.me.x), (self.map.length - self.me.y))
+    // }
 
 
 };

--- a/bots/mainbot/movement.js
+++ b/bots/mainbot/movement.js
@@ -215,5 +215,18 @@ movement.condense_path = (speed, path) => {
     return condensed_path;
 };
 
+movement.random = (self) => {
+
+    let dx = Math.floor(Math.random() * 3) - 1;
+    let dy = Math.floor(Math.random() * 3) - 1;
+
+    if (utilities.isOpen(self, {x: self.me.x + dx, y: self.me.y + dy})) {
+        utilities.log(self, "Randomly moving from (" + self.me.x + ", " + self.me.y + ") stepping (" + dx + ", " + dy + ")");
+        return self.move(dx, dy);
+    } else {
+        utilities.log(self, "Random movement location occupied.");
+        return;
+    };
+}
 
 export default movement;

--- a/bots/mainbot/prophet.js
+++ b/bots/mainbot/prophet.js
@@ -89,12 +89,12 @@ prophet.buildPhase = (self, enemies) => {
         // Track where the robot spawned
         self.home = utilities.findClosestCastle(self);
     }
-    let distFromCastle = utilities.getDistance({x: self.me.x, y: self.me.y}, self.home);
+    let distFromCastle = Math.sqrt(utilities.getDistance({x: self.me.x, y: self.me.y}, self.home));
     utilities.log(self, `Distance from castle ${distFromCastle}`);
     if(enemies.length > 0){
         return combat.attackBot(self, enemies[0]);
     }
-    else if(distFromCastle < 2 || !((self.x % 2 !== 0 && self.y % 2 !== 0) || (self.x % 2 !== 1 && self.y % 2 !== 1))){
+    else if((distFromCastle < 2) || (!((self.me.x % 2 !== 0 && self.me.y % 2 !== 1) || (self.me.x % 2 !== 1 && self.me.y % 2 !== 0)))){
         // Move random until we get away from the castle
         return movement.random(self);
     }

--- a/bots/mainbot/prophet.js
+++ b/bots/mainbot/prophet.js
@@ -7,33 +7,78 @@ const prophet = {};
 
 prophet.takeTurn = (self) => {
     self.log("Prophet turn")
-    // let enemies = utilities.enemiesInRange(self);
-    // if (self.moveQueue === undefined) {
-    //     self.moveQueue = [];
-    // }
-    // if(enemies.length > 0){
-    //     for(let i = 0; i < enemies.length; ++i){
-    //         if(enemies[i].unit === SPECS.CASTLE){
-    //             self.log("Attacking Castle");
-    //             return combat.attackBot(self, enemies[i]);
-    //         }
-    //     }
-    // }
-    // if (self.step === 0 ){
-    //     self.log("Searching for castle on horizontal symmetric map");
-    //     self.moveQueue = movement.moveTo(self, (self.map[0].length - self.me.x), (self.me.y))
-    // }
-    // if (self.moveQueue.length !== 0) {
-    //     let move = self.moveQueue.shift();
-    //     self.log("moving to " + (move.x) + ', ' + (move.y));
-    //     return self.move((move.x - self.me.x), (move.y - self.me.y));
-    // }
-    // else if(self.step !== 0 && enemies.length < 1){
-    //     self.log("Searching for castle on vertically symmetric map");
-    //     self.moveQueue = movement.moveTo(self, (self.map[0].length - self.me.x), (self.map.length - self.me.y))
-    // }
+    self.castleTalk(SPECS.PROPHET)
+    if (self.horizontalCastle === undefined){
+        self.horizontalCastle = {x: (self.map[0].length - self.me.x), y: self.me.y};
+    }
+    if (self.verticalCastle === undefined){
+        self.verticalCastle = {x: self.me.x, y: (self.map.length - self.me.y)};
+    }
+    if (self.targetCastle === undefined){
+        self.targetCastle = self.horizontalCastle;
+    }
+    if(self.attacking === undefined){
+        self.attacking = false;
+    }
+    let enemies = utilities.enemiesInRange(self);
+    // If attack skip phase check
+    if (self.attacking === true){
+        utilities.log(self, "Continuing attack phase")
+        return prophet.attackPhase(self, enemies);
+    }
+    // If we aren't attacking check the phase to see if castle has said to attack
+	let phase = utilities.getCastleSignal(self);
 
+	if(phase === 1){
+        self.attacking = true;
+		return prophet.attackPhase(self, enemies);
+	}
+	else{
+		utilities.log(self, "defaulting to build phase");
+        return prophet.buildPhase(self, enemies);
+	}
+};
+
+prophet.attackPhase = (self, enemies) => {
+    utilities.log(self, "Executing Attack Phase turn");
+    if (self.moveQueue === undefined) {
+        self.moveQueue = [];
+    }
+    utilities.log(self, `Found ${enemies.length} enemies near me`)
+    if(enemies.length > 0){
+        for(let i = 0; i < enemies.length; ++i){
+            if(enemies[i].unit === SPECS.CASTLE){
+                self.log("Attacking Castle");
+            }
+            return combat.attackBot(self, enemies[i]);
+        }
+    }
+
+    // If we made it to the horizontal location and there is nothing to attack the castle is probably at the vertical loc
+    if(self.me.x === self.horizontalCastle.x && self.me.y === self.horizontalCastle.y){
+    	self.targetCastle = self.verticalCastle
+	}
+
+    if (self.moveQueue.length !== 0) {
+        let move = self.moveQueue.shift();
+        self.log("moving to " + (move.x) + ', ' + (move.y));
+        try{
+            return self.move((move.x - self.me.x), (move.y - self.me.y));
+		}
+		catch (e) {
+			utilities.log(self, "Caught an error" + e)
+			self.moveQueue = [];
+        }
+    }
+    else{
+        self.log("Moving to target castle at x: " + self.targetCastle.x + ", y: " + self.targetCastle.y);
+        self.moveQueue = movement.moveTo(self, self.targetCastle.x, self.targetCastle.y)
+    }
 
 };
+
+prophet.buildPhase = (self, enemies) => {
+    utilities.log(self, "Executing Build Phase turn");
+}
 
 export default prophet;

--- a/bots/mainbot/prophet.js
+++ b/bots/mainbot/prophet.js
@@ -68,17 +68,36 @@ prophet.attackPhase = (self, enemies) => {
 		catch (e) {
 			utilities.log(self, "Caught an error" + e)
 			self.moveQueue = [];
+			return movement.random(self);
+
         }
     }
     else{
         self.log("Moving to target castle at x: " + self.targetCastle.x + ", y: " + self.targetCastle.y);
-        self.moveQueue = movement.moveTo(self, self.targetCastle.x, self.targetCastle.y)
+        self.moveQueue = movement.moveTo(self, self.targetCastle.x, self.targetCastle.y);
+        if(self.moveQueue.length === 0){
+            self.targetCastle.x += 1;
+            self.targetCastle.y += 1;
+        }
     }
 
 };
 
 prophet.buildPhase = (self, enemies) => {
     utilities.log(self, "Executing Build Phase turn");
-}
+    if(self.home === undefined){
+        // Track where the robot spawned
+        self.home = utilities.findClosestCastle(self);
+    }
+    let distFromCastle = utilities.getDistance({x: self.me.x, y: self.me.y}, self.home);
+    utilities.log(self, `Distance from castle ${distFromCastle}`);
+    if(enemies.length > 0){
+        return combat.attackBot(self, enemies[0]);
+    }
+    else if(distFromCastle < 2 || !((self.x % 2 !== 0 && self.y % 2 !== 0) || (self.x % 2 !== 1 && self.y % 2 !== 1))){
+        // Move random until we get away from the castle
+        return movement.random(self);
+    }
+};
 
 export default prophet;

--- a/bots/mainbot/robot.js
+++ b/bots/mainbot/robot.js
@@ -10,8 +10,9 @@ class MyRobot extends BCAbstractRobot {
         this.myType = undefined;
         this.step = -1;
         this.moveQueue = [];
+		this.attacking = undefined;
     }
-	
+
 	turn() {
         this.step++;
 

--- a/bots/mainbot/utilities.js
+++ b/bots/mainbot/utilities.js
@@ -27,8 +27,10 @@ utilities.enemiesInRange = (self) => {
 	let maxRange = botSpec['ATTACK_RADIUS'][1];
 	let myTeam = self.me.team;
 	let robotsInVision = self.getVisibleRobots();
+	let dist;
 	for(let i = 0; i < robotsInVision.length; ++i){
-		if(robotsInVision[i].team !== myTeam && Math.pow(utilities.getDistance(self.me, robotsInVision[i]), 2) < maxRange){
+		dist = utilities.getDistance(self.me, robotsInVision[i]);
+		if(robotsInVision[i].team !== myTeam && dist < maxRange && dist >= minRange){
 			enemies.push(robotsInVision[i])
 		}
 	}

--- a/bots/mainbot/utilities.js
+++ b/bots/mainbot/utilities.js
@@ -61,4 +61,16 @@ utilities.inMovementRange = (self, loc) => {
 	return utilities.getDistance(self, loc) <= SPECS.UNITS[self.me.unit].SPEED;
 }
 
+utilities.findClosestCastle = (self) => {
+	let visible = self.getVisibleRobots();
+
+	for(let i = 0; i < visible.length; ++i){
+		if(visible[i].unit === SPECS.CASTLE && visible[i].team === self.me.team){
+			return {x: visible[i].x, y: visible[i].y}
+		}
+	}
+	utilities.log(self, `Failed to find a nearby castle`)
+	return undefined
+};
+
 export default utilities;

--- a/bots/mainbot/utilities.js
+++ b/bots/mainbot/utilities.js
@@ -73,4 +73,13 @@ utilities.findClosestCastle = (self) => {
 	return undefined
 };
 
+utilities.getCastleSignal = (self) => {
+	let visibleBots = self.getVisibleRobots();
+	for(let i = 0; i < visibleBots.length; i += 1){
+		if(visibleBots[i].unit === SPECS.CASTLE){
+			return visibleBots[i].signal;
+		}
+	}
+};
+
 export default utilities;


### PR DESCRIPTION
* Add attack phase and build phases for prophets
 - during build phase prophets will randomly move until they reach a checkerboard pattern at least 2 distance away from their home castle. 
 - After a castle has 5 prophets around it, the castle will send a signal to all units within 5 radius that it is time to attack. Prophets that receive the signal will move towards the expected enemy castle locations. 
* Added random movement function to the movement file. Nice to be able to revert to a random movement if bot gets stuck. 
* Added a unit count function to the castle and called it at the beginning of every turn. 
 - Allows the castle to know how many of each unit are within it's range. 
* Minor fixes to some utility functions
* Commented out the crusader functionality for now. @thePurpleMonkey  When you pr your changes to crusader feel free to just use your file if there is a merge conflict. 